### PR TITLE
Fix/conv3dupsample

### DIFF
--- a/perceiver_pytorch/decoders.py
+++ b/perceiver_pytorch/decoders.py
@@ -56,16 +56,17 @@ class ImageDecoder(torch.nn.Module):
             if output_channels == -1:
                 raise ValueError("Expected value for n_outputs")
             if self.temporal_upsample != 1:
-                raise ValueError("Convolutional temporal upsampling is currently not supported")
-                #def int_log2(x):
-                #    return int(np.round(np.log(x) / np.log(2)))
+                # raise ValueError("Convolutional temporal upsampling is currently not supported")
 
-                #self.convnet = Conv3DUpsample(
-                #    input_channels=input_channels,
-                #    output_channels=output_channels,
-                #    num_temporal_upsamples=int_log2(temporal_upsample),
-                #    num_space_upsamples=int_log2(spatial_upsample),
-                #)
+                def int_log2(x):
+                    return int(np.round(np.log(x) / np.log(2)))
+
+                self.convnet = Conv3DUpsample(
+                   input_channels=input_channels,
+                   output_channels=output_channels,
+                   num_temporal_upsamples=int_log2(temporal_upsample),
+                   num_space_upsamples=int_log2(spatial_upsample),
+                )
             else:
                 assert self.spatial_upsample == 4, "Conv2DUpsample only support 4x spatial upsample right now"
                 self.convnet = Conv2DUpsample(

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -61,13 +61,17 @@ def test_conv1x1_video_decoder():
     assert out.size() == (2, 3, 12, 16, 16)
 
 
-#def test_conv3d_video_decoder():
-#    decoder = ImageDecoder(postprocess_type="conv", output_channels=12, input_channels=48, spatial_upsample=4, temporal_upsample=2)
-#    inputs = torch.randn(2, 1, 48, 64, 64)
-#    with torch.no_grad():
-#        out = decoder(inputs)
-#    assert not torch.isnan(out).any(), "Output included NaNs"
-#    assert out.size() == (2, 2, 12, 256, 256)
+def test_conv3d_video_decoder():
+   decoder = ImageDecoder(postprocess_type="conv",
+                          output_channels=12,
+                          input_channels=48,
+                          spatial_upsample=4,
+                          temporal_upsample=2)
+   inputs = torch.randn(2, 1, 48, 64, 64)
+   with torch.no_grad():
+       out = decoder(inputs)
+   assert not torch.isnan(out).any(), "Output included NaNs"
+   assert out.size() == (2, 2, 12, 256, 256)
 
 
 def test_patches_video_decoder():


### PR DESCRIPTION
- set kernel to the same as stride, and link why this works
- add list for intermediate layer sizes
- adjust forward method to go through each layer