### PR TITLE
Bug/perceiver sine only

### DIFF
--- a/perceiver_pytorch/perceiver_pytorch.py
+++ b/perceiver_pytorch/perceiver_pytorch.py
@@ -30,6 +30,7 @@ class Perceiver(nn.Module):
         ff_dropout=0.0,
         weight_tie_layers=False,
         fourier_encode_data=True,
+        sine_only: bool = False,
         self_per_cross_attn=1,
         self_attn_rel_pos=True
     ):
@@ -60,6 +61,7 @@ class Perceiver(nn.Module):
           fourier_encode_data: Whether to auto-fourier encode the data, using
               the input_axis given. defaults to True, but can be turned off
               if you are fourier encoding the data yourself.
+            sine_only: Use only sine encoding in fourier encoding, compared to using sine and cos
           self_per_cross_attn: Number of self attention blocks per cross attn.
         """
         super().__init__()

--- a/perceiver_pytorch/perceiver_pytorch.py
+++ b/perceiver_pytorch/perceiver_pytorch.py
@@ -76,6 +76,7 @@ class Perceiver(nn.Module):
             if fourier_encode_data
             else 0
         )
+        self.sine_only = sine_only
         input_dim = fourier_channels + input_channels
 
         self.latents = nn.Parameter(torch.randn(num_latents, latent_dim))

--- a/tests/test_perceiver_pytorch.py
+++ b/tests/test_perceiver_pytorch.py
@@ -1,0 +1,56 @@
+from perceiver_pytorch.perceiver_pytorch import Perceiver
+import torch
+
+
+def test_init_model():
+
+    _ = Perceiver(
+        input_channels=16,
+        input_axis=2,
+        num_freq_bands=6,
+        max_freq=10,
+        depth=13,
+        num_latents=16,
+        latent_dim=17,
+        num_classes=7,
+        weight_tie_layers=True,
+        fourier_encode_data=False,
+    )
+
+
+def test_model_forward():
+
+    model = Perceiver(
+        input_channels=16,
+        input_axis=2,
+        num_freq_bands=6,
+        max_freq=10,
+        depth=13,
+        num_latents=16,
+        latent_dim=17,
+        num_classes=7,
+        weight_tie_layers=True,
+        fourier_encode_data=False,
+    )
+
+    x = torch.randn(8 * 13, 32, 32, 16)
+    y = model(x)
+
+
+def test_model_forward_fourier():
+
+    model = Perceiver(
+        input_channels=16,
+        input_axis=2,
+        num_freq_bands=6,
+        max_freq=10,
+        depth=13,
+        num_latents=16,
+        latent_dim=17,
+        num_classes=7,
+        weight_tie_layers=True,
+        fourier_encode_data=True,
+    )
+
+    x = torch.randn(8 * 13, 32, 32, 16)
+    y = model(x)


### PR DESCRIPTION
Fix bug for sine-only in perceiver-pytorch
add tests to check it works

I realise that this model might not be used any more, but I thought still worth fixing