### PR TITLE
Add support for Temporally consistent Learnable Queries

### DIFF
--- a/perceiver_pytorch/queries.py
+++ b/perceiver_pytorch/queries.py
@@ -142,6 +142,8 @@ class LearnableQuery(torch.nn.Module):
                 to_concat = to_concat + [ff, fourier_features]
             else:
                 to_concat = to_concat + [fourier_features]
+        else:
+            to_concat = to_concat + [ff]
         query = torch.cat(to_concat, dim=-1)
         # concat to channels of data and flatten axis
         query = einops.rearrange(query, "b ... d -> b (...) d")

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
     name="perceiver-model",
     packages=find_packages(),
-    version="0.7.2",
+    version="0.7.3",
     license="MIT",
     description="Multimodal Perceiver - Pytorch",
     author="Jacob Bieker, Jack Kelly, Peter Dudfield",

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -78,7 +78,7 @@ def test_learnable_query_precomputed_fourier_only(layer_shape):
         num_frequency_bands=16,
         sine_only=False,
         precomputed_fourier=precomputed_features,
-        use_both_precomputed_and_generated_fourier=False,
+        generate_fourier_features=False,
     )
     x = torch.randn((4, 6, 12, 16, 16))
     out = query_creator(x)
@@ -109,7 +109,7 @@ def test_learnable_query_precomputed_and_generated_fourer(layer_shape):
         num_frequency_bands=128,
         sine_only=False,
         precomputed_fourier=precomputed_features,
-        use_both_precomputed_and_generated_fourier=True,
+        generate_fourier_features=True,
     )
     x = torch.randn((4, 6, 12, 16, 16))
     out = query_creator(x)
@@ -140,7 +140,7 @@ def test_learnable_query_pass_in_fourier(layer_shape):
         frequency_base=2.0,
         num_frequency_bands=128,
         sine_only=False,
-        use_both_precomputed_and_generated_fourier=False,
+        generate_fourier_features=False,
     )
     x = torch.randn((4, 6, 12, 16, 16))
     out = query_creator(x, precomputed_features)
@@ -182,7 +182,7 @@ def test_learnable_query_all_fouriers(layer_shape):
         num_frequency_bands=128,
         sine_only=False,
         precomputed_fourier=precomputed_features,
-        use_both_precomputed_and_generated_fourier=True,
+        generate_fourier_features=True,
     )
     x = torch.randn((4, 6, 12, 16, 16))
     out = query_creator(x, batch_ff)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -27,6 +27,23 @@ def test_learnable_query(layer_shape):
 
 
 @pytest.mark.parametrize("layer_shape", ["2d", "3d"])
+def test_learnable_query_no_fourier(layer_shape):
+    query_creator = LearnableQuery(
+        channel_dim=32,
+        query_shape=(6, 16, 16),
+        conv_layer=layer_shape,
+        max_frequency=64.0,
+        frequency_base=2.0,
+        num_frequency_bands=128,
+        sine_only=False,
+        generate_fourier_features=False,
+    )
+    x = torch.randn((4, 6, 12, 16, 16))
+    out = query_creator(x)
+    assert out.shape == (4, 16 * 16 * 6, 32)
+
+
+@pytest.mark.parametrize("layer_shape", ["2d", "3d"])
 def test_learnable_query_qpplication(layer_shape):
     output_shape = (6, 16, 16)
     query_creator = LearnableQuery(

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -16,6 +16,7 @@ def test_learnable_query(layer_shape):
         frequency_base=2.0,
         num_frequency_bands=128,
         sine_only=False,
+        generate_fourier_features=True,
     )
     x = torch.randn((4, 6, 12, 16, 16))
     out = query_creator(x)
@@ -36,6 +37,7 @@ def test_learnable_query_qpplication(layer_shape):
         frequency_base=2.0,
         num_frequency_bands=32,
         sine_only=False,
+        generate_fourier_features=True,
     )
     with torch.no_grad():
         query_creator.eval()

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -118,3 +118,35 @@ def test_learnable_query_precomputed_and_generated_fourer(layer_shape):
     # 32 + 3*(257) = 771 + 32 = 803
     # Then add 771 from the precomputed features, to get 803 + 771
     assert out.shape == (4, 16 * 16 * 6, 803 + 771)
+
+
+@pytest.mark.parametrize("layer_shape", ["2d", "3d"])
+def test_learnable_query_pass_in_fourier(layer_shape):
+    precomputed_features = encode_position(
+        4,
+        axis=(10, 16, 16),  # 4 history + 6 future steps
+        max_frequency=16.0,
+        frequency_base=2.0,
+        num_frequency_bands=64,
+        sine_only=False,
+    )
+    # Only take future ones
+    precomputed_features = precomputed_features[:, 4:]
+    query_creator = LearnableQuery(
+        channel_dim=32,
+        query_shape=(6, 16, 16),
+        conv_layer=layer_shape,
+        max_frequency=64.0,
+        frequency_base=2.0,
+        num_frequency_bands=128,
+        sine_only=False,
+        precomputed_fourier=precomputed_features,
+        use_both_precomputed_and_generated_fourier=False,
+    )
+    x = torch.randn((4, 6, 12, 16, 16))
+    out = query_creator(x, precomputed_features)
+    # Output is flattened, so should be [B, T*H*W, C]
+    # Channels is from channel_dim + 3*(num_frequency_bands * 2 + 1)
+    # 3*(129) = 389 + 32 = 419
+    # Since this is less than what is passed to LearnableQuery, we know its using the passed in features
+    assert out.shape == (4, 16 * 16 * 6, 419)


### PR DESCRIPTION
# Pull Request

## Description

This adds support in the `LearnableQuery` for passing in precomputed Fourier Features, either during construction, or in the forward pass, or both. 

Fixes issue #20 

## How Has This Been Tested?

Unit tests

- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
